### PR TITLE
More updates to tests and request validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.1.3] - 2024-08-28
+
+### Added
+- More request validation (headers, search params)
+- More tests
+- Constants for various HTTP Headers, etc (avoids typos)
+- Add support for `URLPattern` in `allowOrigins`
+- Support multiple types of return values and convert to `Response` (eg `Blob`, `URL`, numbers) as best as reasonable
+
 ## [v1.1.2] - 2024-08-26
 
 ### Added

--- a/RequestHandlerTest.js
+++ b/RequestHandlerTest.js
@@ -5,6 +5,7 @@ import { NetlifyRequest } from './NetlifyRequest.js';
 import { HTML, JSON as JSON_MIME, JSON_LD, FORM_MULTIPART, FORM_URL_ENCODED, TEXT } from '@shgysk8zer0/consts/mimes.js';
 import { loadModuleHandler, getFileURL } from './utils.js';
 import { HTTPError } from './error.js';
+import { ACAO, ACAC, ACAM, ACAH, ACRM, ACRH, ACEH, LOC, AUTH, CONTENT_TYPE, ORIGIN, ACCEPT, ALLOW } from './consts.js';
 
 const between = (min, val, max) => ! (val < min || max > max);
 
@@ -180,7 +181,7 @@ export class RequestHandlerTest {
 			return false;
 		} else if (this.#response.redirected) {
 			return true;
-		} else if (REDIRECT_STATUSES.includes(this.#response.status) && this.#response.headers.has('Location')) {
+		} else if (REDIRECT_STATUSES.includes(this.#response.status) && this.#response.headers.has(LOC)) {
 			return true;
 		} else {
 			return false;
@@ -228,7 +229,7 @@ export class RequestHandlerTest {
 	 * @returns {string | null} The Content-Type header value, or null if the response does not have a Content-Type header.
 	 */
 	get contentType() {
-		return this.headers.get('Content-Type');
+		return this.headers.get(CONTENT_TYPE);
 	}
 
 	/**
@@ -442,10 +443,10 @@ export class RequestHandlerTest {
 	allowsOrigin(origin) {
 		if (typeof origin !== 'string' || ! (this.#response instanceof Response)) {
 			return false;
-		} else if (! this.#response.headers.has('Access-Control-Allow-Origin')) {
+		} else if (! this.#response.headers.has(ACAO)) {
 			return false;
 		} else {
-			const allowed = this.#response.headers.get('Access-Control-Allow-Origin');
+			const allowed = this.#response.headers.get(ACAO);
 
 			if (allowed === '*') {
 				return true;
@@ -550,28 +551,28 @@ export class RequestHandlerTest {
 	}
 
 	/**
-	 * Throws an error if the response status is NOT_ACCEPTABLE and the request header 'Accept' is present.
+	 * Throws an error if the response status is NOT_ACCEPTABLE and the request header ACCEPT is present.
 	 *
 	 * @param {Response} resp - The response object.
 	 * @param {NetlifyRequest} req - The Netlify request object.
-	 * @throws {Error} If the response status is NOT_ACCEPTABLE and the request header 'Accept' is present.
+	 * @throws {Error} If the response status is NOT_ACCEPTABLE and the request header ACCEPT is present.
 	 */
 	static shouldAccept(resp, req) {
-		if (req.headers.has('Accept') && resp.status === NOT_ACCEPTABLE) {
-			throw new Error(`${req.method } <${req.url}> should accept ${req.headers.get('Accept')}.`);
+		if (req.headers.has(ACCEPT) && resp.status === NOT_ACCEPTABLE) {
+			throw new Error(`${req.method } <${req.url}> should accept ${req.headers.get(ACCEPT)}.`);
 		}
 	}
 
 	/**
-	 * Throws an error if the response status is not NOT_ACCEPTABLE and the request header 'Accept' is present.
+	 * Throws an error if the response status is not NOT_ACCEPTABLE and the request header ACCEPT is present.
 	 *
 	 * @param {Response} resp - The response object.
 	 * @param {NetlifyRequest} req - The Netlify request object.
-	 * @throws {Error} If the response status is not NOT_ACCEPTABLE and the request header 'Accept' is present.
+	 * @throws {Error} If the response status is not NOT_ACCEPTABLE and the request header ACCEPT is present.
 	 */
 	static shouldNotAccept(resp, req) {
-		if (req.headers.has('Accept') && resp.status !== NOT_ACCEPTABLE) {
-			throw new Error(`${req.method } <${req.url}> should not accept ${req.headers.get('Accept')}.`);
+		if (req.headers.has(ACCEPT) && resp.status !== NOT_ACCEPTABLE) {
+			throw new Error(`${req.method } <${req.url}> should not accept ${req.headers.get(ACCEPT)}.`);
 		}
 	}
 
@@ -584,10 +585,10 @@ export class RequestHandlerTest {
 	 */
 	static shouldHaveContentType(type) {
 		return (resp, req) => {
-			if (! resp.headers.has('Content-Type')) {
+			if (! resp.headers.has(CONTENT_TYPE)) {
 				throw new Error(`${req.method } <${req.url}> should have a Content-Type set.`);
-			} else if (resp.headers.get('Content-Type').toLowerCase().split(';')[0] !== type.toLowerCase() ) {
-				throw new Error(`${req.method } <${req.url}> should have a Content-Type of ${type}} but got ${resp.headers.get('Content-Type')}.`);
+			} else if (resp.headers.get(CONTENT_TYPE).toLowerCase().split(';')[0] !== type.toLowerCase() ) {
+				throw new Error(`${req.method } <${req.url}> should have a Content-Type of ${type}} but got ${resp.headers.get(CONTENT_TYPE)}.`);
 			}
 		};
 	}
@@ -864,10 +865,10 @@ export class RequestHandlerTest {
 	static shouldRedirect(resp, req) {
 		if (! REDIRECT_STATUSES.includes(resp.status)) {
 			throw new Error(`${req.method} <${req.url}> should have a 3xx redirect status code, but got ${resp.status}.`);
-		} else if (! resp.headers.has('Location')) {
+		} else if (! resp.headers.has(LOC)) {
 			throw new Error(`${req.method} <${req.url}> should redirect but is missing the Location HTTP header.`);
-		} else if (! URL.canParse(resp.headers.get('Location'), req.url)) {
-			throw new Error(`${req.method} <${req.url}> should redirect to a valid URL - got ${resp.headers.get('Location')}.`);
+		} else if (! URL.canParse(resp.headers.get(LOC), req.url)) {
+			throw new Error(`${req.method} <${req.url}> should redirect to a valid URL - got ${resp.headers.get(LOC)}.`);
 		}
 	}
 
@@ -883,18 +884,18 @@ export class RequestHandlerTest {
 	 */
 	static shouldRedirectTo(dest) {
 		return (resp, req) => {
-			const loc = URL.parse(resp.headers.get('Location'), req.url);
+			const loc = URL.parse(resp.headers.get(LOC), req.url);
 
 			if (! REDIRECT_STATUSES.includes(resp.status)) {
 				throw new Error(`${req.method} <${req.url}> should have a 3xx redirect status code, but got ${resp.status}.`);
-			} else if (! resp.headers.has('Location')) {
+			} else if (! resp.headers.has(LOC)) {
 				throw new Error(`${req.method} <${req.url}> should redirect but is missing the Location HTTP header.`);
 			} else if (! (loc instanceof URL)) {
-				throw new Error(`${req.method} <${req.url}> should redirect to a valid URL - got ${resp.headers.get('Location')}.`);
+				throw new Error(`${req.method} <${req.url}> should redirect to a valid URL - got ${resp.headers.get(LOC)}.`);
 			} else if (typeof dest === 'string' && loc.href !== dest) {
 				throw new Error(`${req.method} <${req.url}> should redirect to ${dest} but gave ${loc}.`);
 			} else if (dest instanceof RegExp && ! dest.test(loc.href)) {
-				throw new Error(`${req.method} <${req.url}> redirected to ${resp.headers.get('Location')}, which does not match ${dest}.`);
+				throw new Error(`${req.method} <${req.url}> redirected to ${resp.headers.get(LOC)}, which does not match ${dest}.`);
 			} else if (dest instanceof URLPattern && ! dest.test(loc.href)) {
 				throw new Error(`${req.method} <${req.url}> redirected to ${loc}, which does not match the URLPattern.`);
 			} else if (
@@ -917,12 +918,12 @@ export class RequestHandlerTest {
 	 * @throws {Error} If the Access-Control-Allow-Origin header is missing or does not allow the request's origin.
 	 */
 	static shouldAllowOrigin(resp, req) {
-		if (! resp.headers.has('Access-Control-Allow-Origin')) {
+		if (! resp.headers.has(ACAO)) {
 			throw new Error(`${req.method} <${req.url}> missing Access-Control-Allow-Origin header.`);
-		} else if (req.headers.has('Origin')) {
-			const origin = req.headers.get('Origin');
+		} else if (req.headers.has(ORIGIN)) {
+			const origin = req.headers.get(ORIGIN);
 
-			if (! ['*', origin].includes(resp.headers.get('Access-Control-Allow-Origin'))) {
+			if (! ['*', origin].includes(resp.headers.get(ACAO))) {
 				throw new Error(`${req.method} <${req.url}> should allow origin: ${origin}.`);
 			}
 		}
@@ -952,10 +953,10 @@ export class RequestHandlerTest {
 	 * @throws {Error} If the Access-Control-Allow-Origin header is missing or allows the request's origin.
 	 */
 	static async shouldDisallowOrigin(resp, req) {
-		if (resp.headers.has('Access-Control-Allow-Origin')) {
-			const origin = req.headers.get('Origin');
+		if (resp.headers.has(ACAO)) {
+			const origin = req.headers.get(ORIGIN);
 
-			if (['*', origin].includes(resp.headers.get('Access-Control-Allow-Origin'))) {
+			if (['*', origin].includes(resp.headers.get(ACAO))) {
 				throw new Error(`${req.method} <[>${req.url}> should allow not origin: ${origin}.`);
 			}
 		}
@@ -972,11 +973,11 @@ export class RequestHandlerTest {
 	 * - The `Access-Control-Allow-Origin` header is set to `"*"` while credentials are allowed.
 	 */
 	static async shouldAllowCredentials(resp, req) {
-		if (! resp.headers.has('Access-Control-Allow-Credentials')) {
+		if (! resp.headers.has(ACAC)) {
 			throw new Error(`${req.method} <[>${req.url}> is missing Access-Control-Allow-Credentials header.`);
-		} else if (! resp.headers.has('Access-Control-Allow-Origin')) {
+		} else if (! resp.headers.has(ACAO)) {
 			throw new Error(`${req.method} <[>${req.url}> is missing Access-Control-Allow-Origin header.`);
-		} else if (resp.headers.get('Access-Control-Allow-Origin') === '*') {
+		} else if (resp.headers.get(ACAO) === '*') {
 			throw new Error(`${req.method} <[>${req.url}> is Access-Control-Allow-Origin may not be "*" if credentials are allowed.`);
 		}
 	}
@@ -990,7 +991,7 @@ export class RequestHandlerTest {
 	static async shouldSupportOptionsMethod(resp, req) {
 		if (req.method !== 'OPTIONS') {
 			throw new TypeError(`${req.method} <${req.url}> is not an OPTIONS request, so this test is invalid.`);
-		} else if (! resp.headers.has('Access-Control-Allow-Methods')) {
+		} else if (! resp.headers.has(ACAM)) {
 			throw new Error(`${req.method} <${req.url}> missing Access-Control-Allow-Methods in OPTIONS request.`);
 		}
 	}
@@ -1002,10 +1003,10 @@ export class RequestHandlerTest {
 	 * @throws {Error} If the response status is 405 Method Not Allowed.
 	 */
 	static shouldAllowMethod(resp, req) {
-		if (req.method === 'OPTIONS' && req.headers.has('Access-Control-Request-Method')) {
-			const method = req.headers.get('Access-Control-Request-Method').trim().toUpperCase();
-			const allowed = resp.headers.has('Access-Control-Allow-Methods')
-				? resp.headers.get('Access-Control-Allow-Methods').split(',').map(method => method.trim().toUpperCase())
+		if (req.method === 'OPTIONS' && req.headers.has(ACRM)) {
+			const method = req.headers.get(ACRM).trim().toUpperCase();
+			const allowed = resp.headers.has(ACAM)
+				? resp.headers.get(ACAM).split(',').map(method => method.trim().toUpperCase())
 				: [];
 
 			if (! allowed.includes(method)) {
@@ -1017,17 +1018,38 @@ export class RequestHandlerTest {
 	}
 
 	/**
-	 * Checks if a response has a specified header.
+	 * Checks if a response has a list of headers.
 	 *
-	 * @param {string} name The name of the required header.
+	 * @param {...string} headers The names of the required headers.
 	 * @returns {function(Response, Request): void} A middleware function.
 	 *
-	 * @throws {Error} If the header is missing and the response status is successful.
+	 * @throws {Error} If one or more header is missing and the response status is successful.
 	 */
-	static shouldRequireHeader(name) {
+	static shouldRequireHeaders(...headers) {
 		return (resp, req) => {
-			if (resp.ok && ! req.headers.has(name)) {
-				throw new Error(`${req.method} <${req.url}> should require "${name}" header but returned a status of ${resp.status}.`);
+			const missing = headers.filter(header => ! req.headers.has(header));
+
+			if (resp.ok && missing.length !== 0) {
+				throw new Error(`${req.method} <${req.url}> should require headers: [${missing.join(', ')}] but returned a status of ${resp.status}.`);
+			}
+		};
+	}
+
+	/**
+	 * Checks if a response has specified search params.
+	 *
+	 * @param {...string} params The names of the required search params.
+	 * @returns {function(Response, Request): void} A middleware function.
+	 *
+	 * @throws {Error} If the search param is missing and the response status is successful.
+	 */
+	static shouldRequireSearchParams(...params) {
+		return (resp, req) => {
+			const searchParams = new URLSearchParams(req.url);
+			const missing = params.filter(header => ! searchParams.has(header));
+
+			if (resp.ok && missing.length !== 0) {
+				throw new Error(`${req.method} <${req.url}> should require search params: [${missing.join(', ')}] but returned a status of ${resp.status}.`);
 			}
 		};
 	}
@@ -1037,14 +1059,13 @@ export class RequestHandlerTest {
 
 	* @param {Response} resp The response object.
 	* @param {Request} req The request object.
-
 	* @throws {Error} If the header is missing and the response status is not 401.
 	* @throws {Error} If the header is present and the response status is 401.
 	*/
 	static shouldRequireAuthorization(resp, req) {
-		if (! req.headers.has('Authorization') && resp.status !== UNAUTHORIZED) {
+		if (! req.headers.has(AUTH) && resp.status !== UNAUTHORIZED) {
 			throw new Error(`${req.method} <${req.url}> should return a status of ${UNAUTHORIZED} if request is missing "Authorization" header but got ${resp.status}.`);
-		} else if (req.headers.has('Authorization') && resp.status === UNAUTHORIZED) {
+		} else if (req.headers.has(AUTH) && resp.status === UNAUTHORIZED) {
 			throw new Error(`${req.method} <${req.url}> had required "Authorization" header but still got ${UNAUTHORIZED} Unauthorized.`);
 		}
 	}
@@ -1059,10 +1080,10 @@ export class RequestHandlerTest {
 	 */
 	static shouldAllowHeaders(...headers) {
 		return (resp, req) => {
-			if (! resp.headers.has('Access-Control-Allow-Headers')) {
+			if (! resp.headers.has(ACAH)) {
 				throw new Error(`${req.method} <${req.url}> missing Access-Control-Allow-Headers.`);
 			} else {
-				const allowed = getAllHeader(resp, 'Access-Control-Allow-Headers');//resp.headers.get('Access-Control-Allow-Headers').split(',').map(header => header.trim().toLowerCase());
+				const allowed = getAllHeader(resp, ACAH);//resp.headers.get(ACAH).split(',').map(header => header.trim().toLowerCase());
 				const missing = headers.filter(header => ! allowed.includes(header.toLowerCase()));
 
 				if (missing.length !== 0) {
@@ -1082,10 +1103,10 @@ export class RequestHandlerTest {
 	 */
 	static shouldNotAllowHeaders(...headers) {
 		return (resp, req) => {
-			if (! resp.headers.has('Access-Control-Allow-Headers')) {
+			if (! resp.headers.has(ACAH)) {
 				throw new Error(`${req.method} <${req.url}> missing Access-Control-Allow-Headers.`);
 			} else {
-				const allowed = resp.headers.get('Access-Control-Allow-Headers').split(',').map(header => header.trim().toLowerCase());
+				const allowed = resp.headers.get(ACAH).split(',').map(header => header.trim().toLowerCase());
 				const disallowed = headers.filter(header => allowed.includes(header.toLowerCase()));
 
 				if (headers.length !== 0) {
@@ -1104,10 +1125,10 @@ export class RequestHandlerTest {
 	 * @param {Request} req The request object.
 	 */
 	static shouldAllowRequestHeaders(resp, req) {
-		if (req.method === 'OPTIONS' && req.headers.has('Access-Control-Request-Headers')) {
-			if (resp.headers.has('Access-Control-Allow-Headers')) {
-				const reqHeaders = getAllHeader(req, 'Access-Control-Request-Headers');
-				const allowHeaders = getAllHeader(resp, 'Access-Control-Allow-Headers');
+		if (req.method === 'OPTIONS' && req.headers.has(ACRH)) {
+			if (resp.headers.has(ACAH)) {
+				const reqHeaders = getAllHeader(req, ACRH);
+				const allowHeaders = getAllHeader(resp, ACAH);
 				const disallowed = reqHeaders.filter(header => ! allowHeaders.includes(header));
 
 				if (disallowed.length !== 0) {
@@ -1127,11 +1148,11 @@ export class RequestHandlerTest {
 	 */
 	static shouldExposeHeaders(...headers) {
 		return (resp, req) => {
-			if (! resp.headers.has('Access-Control-Expose-Headers')) {
+			if (! resp.headers.has(ACEH)) {
 				throw new Error(`${req.method} <${req.url}> response missing Access-Control-Expose-Headers.`);
 			} else {
-				const exposed = getAllHeader(resp, 'Access-Control-Expose-Headers');
-				//resp.headers.get('Access-Control-Expose-Headers').split(',').map(header => header.trim().toLowerCase());
+				const exposed = getAllHeader(resp, ACEH);
+				//resp.headers.get(ACEH).split(',').map(header => header.trim().toLowerCase());
 				const missing = headers.filter(header => ! exposed.includes(header.toLowerCase()));
 
 				if (missing.length !== 0) {
@@ -1151,8 +1172,8 @@ export class RequestHandlerTest {
 	 */
 	static shouldNotExposeHeaders(...headers) {
 		return (resp, req) => {
-			if (resp.headers.has('Access-Control-Expose-Headers')) {
-				const exposed = getAllHeader(resp, 'Access-Control-Expose-Headers');
+			if (resp.headers.has(ACEH)) {
+				const exposed = getAllHeader(resp, ACEH);
 				const disallowed = headers.filter(header => exposed.includes(header.toLowerCase()));
 
 				if (disallowed.length !== 0) {
@@ -1169,10 +1190,10 @@ export class RequestHandlerTest {
 	 * @throws {Error} If the response status is not 405 Method Not Allowed.
 	 */
 	static shouldNotAllowMethod(resp, req) {
-		if (req.method === 'OPTIONS' && req.headers.has('Access-Control-Request-Method')) {
-			const method = req.headers.get('Access-Control-Request-Method').trim().toUpperCase();
-			const allowed = resp.headers.has('Access-Control-Allow-Methods')
-				? resp.headers.get('Access-Control-Allow-Methods').split(',').map(method => method.trim().toUpperCase())
+		if (req.method === 'OPTIONS' && req.headers.has(ACRM)) {
+			const method = req.headers.get(ACRM).trim().toUpperCase();
+			const allowed = resp.headers.has(ACAM)
+				? resp.headers.get(ACAM).split(',').map(method => method.trim().toUpperCase())
 				: [];
 
 			if (allowed.includes(method)) {
@@ -1180,9 +1201,9 @@ export class RequestHandlerTest {
 			}
 		} else if (resp.status !== METHOD_NOT_ALLOWED) {
 			throw new Error(`${req.method} <${req.url}> should not support HTTP method "${req.method}. Got status [${resp.status}]."`);
-		} else if (! resp.headers.has('Allow')) {
+		} else if (! resp.headers.has(ALLOW)) {
 			throw new Error(`${req.method} <${req.url}> not allowed, but is missing Allow header.`);
-		} else if (resp.headers.get('Allow').split(',').map(method => method.trim().toUpperCase()).includes(req.method)) {
+		} else if (resp.headers.get(ALLOW).split(',').map(method => method.trim().toUpperCase()).includes(req.method)) {
 			throw new Error(`${req.method} <${req.url}> not allowed, but is listed as an allowed method.`);
 		}
 	}
@@ -1196,7 +1217,7 @@ export class RequestHandlerTest {
 	 * @param {Request} req The request object.
 	 */
 	static shouldBeCorsResponse(resp, req) {
-		if (! resp.headers.has('Access-Control-Allow-Origin')) {
+		if (! resp.headers.has(ACAO)) {
 			throw new Error(`${req.method} <${req.url}> is missing required Access-Control-Allow-Origin header.`);
 		}
 	}
@@ -1214,14 +1235,14 @@ export class RequestHandlerTest {
 		if (resp.status !== UNAUTHORIZED && req.credentials === 'omit') {
 			throw new Error(`${req.method} <${req.url}> should require credentials.`);
 		} else if (req.mode === 'cors') {
-			if (resp.headers.get('Access-Control-Allow-Credentials') !== 'true') {
+			if (resp.headers.get(ACAC) !== 'true') {
 				throw new Error(`${resp.method} <${resp.url}> missing required Access-Control-Allow-Credentials header.`);
-			} else if (! resp.headers.has('Access-Control-Allow-Origin')) {
-				throw new Error(`${resp.method} <${resp.url}> missing required Access-Control-Allow-Origin header.`);
-			} else if (! URL.canParse(req.headers.get('Access-Control-Allow-Origin'))) {
-				throw new Error(`${resp.method} <${resp.url}> invalid Access-Control-Allow-Origin header: ${resp.headers.get('Access-Control-Allow-Origin')}.`);
-			} else if (req.headers.get('Origin') !== resp.headers.get('Access-Control-Allow-Origin')) {
-				throw new Error(`${req.method} <${req.url}> origin mismatch. Request from ${req.headers.get('origin')} but allows ${resp.headers.get('Access-Control-Allow-Origin')}`);
+			} else if (! resp.headers.has(ACAO)) {
+				throw new Error(`${req.method} <${req.url}> missing required Access-Control-Allow-Origin header.`);
+			} else if (! URL.canParse(resp.headers.get(ACAO))) {
+				throw new Error(`${req.method} <${req.url}> invalid Access-Control-Allow-Origin header: ${resp.headers.get(ACAO)}.`);
+			} else if (req.headers.get(ORIGIN) !== resp.headers.get(ACAO)) {
+				throw new Error(`${req.method} <${req.url}> origin mismatch. Request from ${req.headers.get(ORIGIN)} but allows ${resp.headers.get(ACAO)}`);
 			}
 		}
 	}
@@ -1251,28 +1272,28 @@ export class RequestHandlerTest {
 	static shouldPassPreflight(resp, req) {
 		if (req.method !== 'OPTIONS') {
 			throw new TypeError(`${req.method} <${req.url}> preflight tests only apply to OPTIONS requests.`);
-		} else if (req.mode !== 'cors' || ! req.headers.has('Origin')) {
+		} else if (req.mode !== 'cors' || ! req.headers.has(ORIGIN)) {
 			throw new Error(`${req.method} <${req.url}> is not a valid CORS request.`);
-		} else if (! URL.parse(req.headers.get('Origin'))?.origin === req.headers.get('Origin')) {
-			throw new Error(`${req.method} <${req.url}> has an invalid Origin of "${req.headers.get('Origin')}".`);
-		} else if (! req.headers.has('Access-Control-Request-Method')) {
+		} else if (! URL.parse(req.headers.get(ORIGIN))?.origin === req.headers.get(ORIGIN)) {
+			throw new Error(`${req.method} <${req.url}> has an invalid Origin of "${req.headers.get(ORIGIN)}".`);
+		} else if (! req.headers.has(ACRM)) {
 			throw new Error(`${req.method} <${req.url}> is missing required Access-Control-Request-Method header.`);
 		} else if (! (resp.status === OK || resp.status === NO_CONTENT)) {
 			throw new Error(`${req.method} <${req.url}> expected a 2xx status but got ${resp.status}.`);
-		} else if (! getAllHeader(resp, 'Access-Control-Allow-Methods').includes(req.headers.get('Access-Control-Request-Method').toLowerCase())) {
-			throw new Error(`${req.method} <${req.url}> expected to allow ${req.headers.get('Access-Control-Request-Method')} but does not.`);
+		} else if (! getAllHeader(resp, ACAM).includes(req.headers.get(ACRM).toLowerCase())) {
+			throw new Error(`${req.method} <${req.url}> expected to allow ${req.headers.get(ACRM)} but does not.`);
 		} else if (resp.body instanceof ReadableStream) {
 			throw new Error(`${resp.method} <${resp.url}> - Options response must not have a body.`);
 		} else if (
 			req.credentials === 'include'
-			&& (! resp.headers.has('Access-Control-Allow-Origin') || resp.headers.get('Access-Control-Allow-origin') !== req.headers.get('Origin'))
+			&& (! resp.headers.has(ACAO) || resp.headers.get(ACAO) !== req.headers.get(ORIGIN))
 		) {
 			throw new Error(`${req.method} <${req.url}> has misconfigured CORS headers for a credentialed request.`);
 		} else {
-			const reqHeaders = getAllHeader(req, 'Access-Control-Request-Headers');
+			const reqHeaders = getAllHeader(req, ACRH);
 
 			if (reqHeaders.length !== 0) {
-				const allowed = getAllHeader(resp, 'Access-Control-Allow-Headers');
+				const allowed = getAllHeader(resp, ACAH);
 				const missing = reqHeaders.filter(header => ! allowed.includes(header));
 
 				if (missing.length !== 0) {
@@ -1326,8 +1347,8 @@ export class RequestHandlerTest {
 	 * @param {Response} resp - The response object whose body are to be logged.
 	 */
 	static async logResponseBody(resp) {
-		if (resp.headers.has('Content-Type')) {
-			switch(resp.headers.get('Content-Type').toLowerCase()) {
+		if (resp.headers.has(CONTENT_TYPE)) {
+			switch(resp.headers.get(CONTENT_TYPE).toLowerCase()) {
 				case '':
 					 console.log(null);
 					 break;
@@ -1348,7 +1369,7 @@ export class RequestHandlerTest {
 					break;
 
 				default:
-					console.log(resp.clone().headers.get('Content-Type').endsWith('+json') ? await resp.clone().json() : await resp.clone().blob());
+					console.log(resp.clone().headers.get(CONTENT_TYPE).endsWith('+json') ? await resp.clone().json() : await resp.clone().blob());
 			}
 		}
 	}

--- a/TestRequest.js
+++ b/TestRequest.js
@@ -1,9 +1,6 @@
 
-const DESTINATIONS = [
-	'', 'audio', 'audioworklet', 'document', 'embed', 'fencedframe', 'font', 'frame', 'iframe', 'image',
-	'json', 'manifest', 'object', 'paintworklet', 'report', 'script', 'sharedworker', 'style', 'track',
-	'video', 'worker', 'xslt',
-];
+import { JSON as JSON_MIME } from '@shgysk8zer0/consts/mimes.js';
+import { CONTENT_LENGTH, CONTENT_TYPE, AUTH, REFERRER, DESTINATIONS } from './consts.js';
 
 export class TestRequest extends Request {
 	#destination = '';
@@ -22,15 +19,15 @@ export class TestRequest extends Request {
 			this.headers.set('Sec-Fetch-Dest', destination.length === 0 ? 'empty' : destination);
 		}
 
-		if (! this.headers.has('Content-Length') && this.body instanceof ReadableStream) {
+		if (! this.headers.has(CONTENT_LENGTH) && this.body instanceof ReadableStream) {
 			if (typeof config.body === 'string') {
-				this.headers.set('Content-Length', config.body.length);
+				this.headers.set(CONTENT_LENGTH, config.body.length);
 			} else if (config.body instanceof Blob) {
-				this.headers.set('Content-Length', config.body.size);
+				this.headers.set(CONTENT_LENGTH, config.body.size);
 			} else if (config.body instanceof ArrayBuffer) {
-				this.headers.set('Content-Length', new Uint8Array(config.body).byteLength);
+				this.headers.set(CONTENT_LENGTH, new Uint8Array(config.body).byteLength);
 			} else if (config.body instanceof FormData) {
-				const boundary = this.headers.get('Content-Type').substring(30);
+				const boundary = this.headers.get(CONTENT_TYPE).substring(30);
 				const entries = [...config.body.entries()];
 				const boundaryLength = boundary.length + 2;
 
@@ -48,24 +45,24 @@ export class TestRequest extends Request {
 					}
 				}
 
-				this.headers.set('Content-Length', length);
+				this.headers.set(CONTENT_LENGTH, length);
 			} else if (config.body instanceof URLSearchParams) {
-				this.headers.set('Content-Length', config.body.toString().length);
+				this.headers.set(CONTENT_LENGTH, config.body.toString().length);
 			} else if (config.body instanceof Uint8Array) {
-				this.headers.set('Content-Length', config.body.byteLength);
+				this.headers.set(CONTENT_LENGTH, config.body.byteLength);
 			}
 		}
 
 		if (typeof token === 'string') {
-			this.headers.set('Authorization', `Bearer ${token}`);
+			this.headers.set(AUTH, `Bearer ${token}`);
 		}
 
 		if (! this.headers.has('Sec-Fetch-Mode')) {
 			this.headers.set('Sec-Fetch-Mode', this.mode);
 		}
 
-		if (! this.headers.has('Referer')) {
-			this.headers.set('Referer', this.referrer);
+		if (! this.headers.has(REFERRER)) {
+			this.headers.set(REFERRER, this.referrer);
 		}
 	}
 
@@ -78,18 +75,18 @@ export class TestRequest extends Request {
 	}
 
 	static json(data, url, { method = 'POST', headers = new Headers(), ...config } = {}) {
-		const body = new Blob([JSON.stringify(data)], { type: 'application/json' });
+		const body = new Blob([JSON.stringify(data)], { type: JSON_MIME });
 
 		if (! (headers instanceof Headers)) {
 			headers = new Headers(headers);
 		}
 
-		if (! headers.has('Content-Length')) {
-			headers.set('Content-Length', body.size);
+		if (! headers.has(CONTENT_LENGTH)) {
+			headers.set(CONTENT_LENGTH, body.size);
 		}
 
-		if (! headers.has('Content-Type')) {
-			headers.set('Content-Type', body.type);
+		if (! headers.has(CONTENT_TYPE)) {
+			headers.set(CONTENT_TYPE, body.type);
 		}
 
 		return new TestRequest(url, { method, headers, ...config, body });

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,0 +1,13 @@
+import { createHandler } from '../handler.js';
+import { AUTH } from '../consts.js';
+
+export default createHandler({
+	async get(req) {
+		const bytes = Uint8Array.fromBase64(req.headers.get(AUTH).substring(6).trim());
+		return Response.json(JSON.parse(new TextDecoder().decode(bytes)));
+	}
+}, {
+	allowOrigins: new URLPattern({ hostname: 'localhost', port: ':port(8888|9999)' }),
+	requireHeaders: [AUTH],
+	allowCredentials: true,
+});

--- a/api/base64.js
+++ b/api/base64.js
@@ -12,4 +12,4 @@ async function base64Encode(req) {
 export default createHandler({
 	put: base64Encode,
 	post: base64Encode,
-}, { logger: err => console.error(err) });
+}, { logger: err => console.error(err), requireHeaders: ['Content-Type'] });

--- a/api/cors.js
+++ b/api/cors.js
@@ -7,11 +7,10 @@ export default createHandler({
 			mode: req.mode,
 			destination: req.destination,
 			headers: Object.fromEntries(req.headers),
-			pattern: 'URLPattern' in globalThis,
 		});
 	}
 }, {
 	allowCredentials: true,
 	allowHeaders: ['Authorization'],
-	allowOrigins: ['*'],
+	allowOrigins: new URLPattern({ hostname: 'localhost', port: ':port(8888|9999)' }),
 });

--- a/api/echo.js
+++ b/api/echo.js
@@ -60,14 +60,11 @@ async function createResponse(req) {
 export default createHandler(Object.fromEntries([
 	...['get', 'delete', 'post', 'put'].map(method => [method, createResponse]),
 ]), {
-	allowOrigins: ['http://localhost:9999', 'http://localhost:8888'],
+	allowOrigins: new URLPattern({ hostname: 'localhost', port: ':port(8888|9999)' }),
 	allowHeaders: ['X-Foo', 'Authorization', 'Content-Type'],
 	exposeHeaders: ['X-Bar'],
 	allowCredentials: true,
 	maxContentLength: 50_000,
-	// requireCORS: true,
 	requireSameOrigin: true,
-	// logger(err) {
-	// 	console.error(err);
-	// }
+	requireHeaders: ['X-Foo'],
 });

--- a/api/error.js
+++ b/api/error.js
@@ -1,24 +1,14 @@
 import { createHandler } from '@shgysk8zer0/lambda-http/handler.js';
-import { HTTPError } from '@shgysk8zer0/lambda-http/error.js';
-import { NOT_ACCEPTABLE } from '@shgysk8zer0/consts/status.js';
+import { HTTPNotAcceptableError } from '../error.js';
 
 export default createHandler({
 	async get(req) {
 		if (! req.accepts('application/json')) {
-			throw new HTTPError(`Does not support: ${req.accept.join(', ')}`, NOT_ACCEPTABLE);
+			throw new HTTPNotAcceptableError(`Does not support: ${req.accept.join(', ')}`);
 		} else {
 			return Response.error();
 		}
 	}
 }, {
 	allowOrigins: ['http://localhost:9999', 'http://localhost:8888'],
-	// allowHeaders: ['X-Foo'],
-	exposeHeaders: ['X-Foo'],
-	allowCredentials: true,
-	// logger: console.error,
-	// logger(err) {
-	// 	if (! (err instanceof HTTPError)) {
-	// 		console.error(err);
-	// 	}
-	// },
 });

--- a/api/page.js
+++ b/api/page.js
@@ -13,7 +13,7 @@ export default createHandler({
 		const theme = new Cookie({
 			name: 'theme',
 			value: req.cookies.get('theme') ?? 'dark',
-			expires: performance.now() + 3_600_000,
+			expires: Date.now() + 3_600_000,
 			path: url,
 			domain: url,
 			sameSite: 'lax',
@@ -24,7 +24,7 @@ export default createHandler({
 		const uid = new Cookie({
 			name: 'uid',
 			value: req.cookies.get('uid') ?? crypto.randomUUID(),
-			expires: performance.now() + 3_600_000,
+			expires: Date.now() + 3_600_000,
 			path: url,
 			domain: url,
 			sameSite: 'lax',

--- a/api/script.js
+++ b/api/script.js
@@ -3,7 +3,6 @@ import { JSON as JSON_MIME, JS } from '@shgysk8zer0/consts/mimes.js';
 
 export default createHandler({
 	async get(req) {
-		const headers = new Headers({ 'Content-Type': JS });
 		const reqData = {
 			url: req.url,
 			method: req.method,
@@ -20,7 +19,7 @@ export default createHandler({
 
 		const js = `fetch('./echo', {
 			method: 'POST',
-			mode: 'no-cors',
+			mode: 'cors',
 			credentials: 'include',
 			referrerPolicy: 'origin',
 			headers: new Headers({
@@ -29,8 +28,8 @@ export default createHandler({
 				Accept: '${JSON_MIME}',
 			}),
 			body: '${JSON.stringify(reqData)}',
-		}).then(async resp => ({ headers: Object.fromEntries(resp.headers), body: resp.json()})).then(console.log).catch(console.error);`;
+		}).then(async resp => ({ headers: Object.fromEntries(resp.headers), body: await resp.json()})).then(console.log).catch(console.error);`;
 
-		return new Response([js], { headers });
+		return new Response(js, { headers: { 'Content-Type': JS }});
 	}
 });

--- a/api/svg.js
+++ b/api/svg.js
@@ -24,6 +24,4 @@ export default createHandler({
 
 		return new Response(svg, { headers });
 	}
-}, {
-	logger: err => console.error(err),
 });

--- a/consts.js
+++ b/consts.js
@@ -1,0 +1,24 @@
+/* Constants for CORS headers */
+export const ACAO = 'Access-Control-Allow-Origin';
+export const ACRM = 'Access-Control-Request-Method';
+export const ACAC = 'Access-Control-Allow-Credentials';
+export const ACAM = 'Access-Control-Allow-Methods';
+export const ACAH = 'Access-Control-Allow-Headers';
+export const ACRH = 'Access-Control-Request-Headers';
+export const ACEH = 'Access-Control-Expose-Headers';
+
+/* Constants for other headers */
+export const AUTH = 'Authorization';
+export const LOC = 'Location';
+export const CONTENT_TYPE = 'Content-Type';
+export const CONTENT_LENGTH = 'Content-Length';
+export const ORIGIN = 'Origin';
+export const ACCEPT = 'Accept';
+export const ALLOW = 'Allow';
+export const REFERRER = 'Referer'; // Yes, that is correct
+
+export const DESTINATIONS = [
+	'', 'audio', 'audioworklet', 'document', 'embed', 'fencedframe', 'font', 'frame', 'iframe', 'image',
+	'json', 'manifest', 'object', 'paintworklet', 'report', 'script', 'sharedworker', 'style', 'track',
+	'video', 'worker', 'xslt',
+];

--- a/index.html
+++ b/index.html
@@ -24,19 +24,31 @@
 
 					const encoded = await resp.text();
 					document.getElementById('encoded').textContent = encoded;
-				})
-			})
+				});
+
+				document.forms.echo.addEventListener('submit', async event => {
+					event.preventDefault();
+
+					const resp = await fetch('{{ BASE }}echo', {
+						method: 'POST',
+						headers: { 'X-Foo': 'bar' },
+						body: new FormData(event.target),
+					});
+
+					console.log(resp);
+				});
+			});
 		</script>
 	</head>
 	<body>
 		<p>{{ MESSAGE }}</p>
 		<p>Last updated: <time datetime="{{ TIMESTAMP }}">{{ DATE }}</time></p>
 		<div><a href="{{ BASE }}echo">Test Echo</a></div>
-		<iframe src="{{ BASE }}echo" referrerpolicy="origin" sandbox="" credentialless="" width="600" height="800"></iframe>
+		<!-- <iframe src="{{ BASE }}echo" referrerpolicy="origin" sandbox="" credentialless="" width="600" height="800"></iframe> -->
 		<pre><code>{{ REQUEST }}</code></pre>
 		<pre><code>{{ JSON }}</code></pre>
 		<img src="{{ BASE }}svg" referrerpolicy="no-referrer" />
-		<form method="post" action="{{ BASE }}echo" rel="noreferrer" target="_blank" enctype="multipart/form-data">
+		<form id="echo" method="post" action="{{ BASE }}echo" rel="noreferrer" target="_blank" enctype="multipart/form-data">
 			<fieldset>
 				<legend>Form Test</legend>
 				<div>

--- a/lambda-http.js
+++ b/lambda-http.js
@@ -10,6 +10,7 @@ export * from './document.js';
 export * from './cookies.js';
 export * from './NetlifyRequest.js';
 export * from './error.js';
+export * from './consts.js';
 export { createHandler };
 export { TestRequest } from './TestRequest.js';
 export default createHandler;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/lambda-http",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/lambda-http",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/lambda-http",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A collection of node >= 20 utilities for Netlify Functions and AWS Lambda",
   "keywords": [
     "request",
@@ -49,8 +49,8 @@
     "lint:js": "eslint .",
     "fix:js": "eslint . --fix",
     "build": "npm run build:js",
-    "clean": "rm -f ./*.cjs",
     "build:js": "npm run clean && rollup -c rollup.config.js",
+    "clean": "rm -f ./*.cjs",
     "run:tests": "node ./tests/all.js",
     "create:lock": "npm i --package-lock-only --ignore-scripts --no-audit --no-fund",
     "version:bump": "npm run version:bump:patch",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import nodeResolve from '@rollup/plugin-node-resolve';
 const external = ['@shgysk8zer0/polyfills', '@shgysk8zer0/consts/mimes.js', '@shgysk8zer0/consts/status.js'];
 
-const modules = ['NetlifyRequest', 'RequestHandlerTest', 'TestRequest', 'context', 'cookies', 'document', 'error', 'handler', 'lambda-http', 'utils'];
+const modules = ['NetlifyRequest', 'RequestHandlerTest', 'TestRequest', 'consts', 'context', 'cookies', 'document', 'error', 'handler', 'lambda-http', 'utils'];
 const plugins = [nodeResolve()];
 
 export default modules.map(module => ({
@@ -11,47 +11,6 @@ export default modules.map(module => ({
 	output: {
 		file: `${module}.cjs`,
 		format: 'cjs',
+		exports: 'named',
 	}
 }));
-
-// export default [{
-// 	input: 'lambda-http.js',
-// 	external,
-// 	plugins: [nodeResolve()],
-// 	output: [{
-// 		file: 'lambda-http.mjs',
-// 		format: 'module',
-// 	}, {
-// 		file: 'lambda-http.cjs',
-// 		format: 'cjs',
-// 	}],
-// }, {
-// 	input: 'error.js',
-// 	external,
-// 	plugins: [nodeResolve()],
-// 	output: {
-// 		file: 'error.cjs',
-// 		format: 'cjs',
-// 	},
-// }, {
-// 	input: 'handler.js',
-// 	external,
-// 	output: {
-// 		file: 'handler.cjs',
-// 		format: 'cjs',
-// 	}
-// }, {
-// 	input: 'cookies.js',
-// 	external,
-// 	output: {
-// 		file: 'cookies.cjs',
-// 		format: 'cjs',
-// 	}
-// }, {
-// 	input: 'NetlifyRequest.js',
-// 	external,
-// 	output: {
-// 		file: 'NetlifyRequest.cjs',
-// 		format: 'cjs',
-// 	}
-// }];

--- a/tests/all.js
+++ b/tests/all.js
@@ -1,6 +1,7 @@
 import { RequestHandlerTest } from '../RequestHandlerTest.js';
 
 const { error, duration } = await RequestHandlerTest.loadAndRunTests(
+	import.meta.resolve('./auth.js'),
 	import.meta.resolve('./base64.js'),
 	import.meta.resolve('./cors.js'),
 	import.meta.resolve('./dne.js'),

--- a/tests/auth.js
+++ b/tests/auth.js
@@ -1,0 +1,22 @@
+import { RequestHandlerTest } from '../RequestHandlerTest.js';
+import { TestRequest } from '../TestRequest.js';
+
+const token = new TextEncoder().encode(JSON.stringify({ msg: 'Hello, World!' })).toBase64();
+const url = new URL('http://localhost:8888/api/auth.js');
+const Origin = 'http://localhost:9999';
+const headers = new Headers({ Origin });
+
+const { error } = await RequestHandlerTest.runTests(
+	new RequestHandlerTest(
+		new TestRequest(url, { headers, token, searchParams: { test: 'authorized' }}),
+		[RequestHandlerTest.shouldBeOk, RequestHandlerTest.shouldBeCorsResponse, RequestHandlerTest.shouldRequireCredentials]
+	),
+	new RequestHandlerTest(
+		new TestRequest(url, { headers, searchParams: { test: 'unauthorized' }}),
+		[RequestHandlerTest.shouldClientError, RequestHandlerTest.shouldBeCorsResponse, RequestHandlerTest.shouldRequireAuthorization]
+	),
+);
+
+if (error) {
+	throw error;
+}

--- a/tests/cors.js
+++ b/tests/cors.js
@@ -1,6 +1,7 @@
 import { RequestHandlerTest } from '../RequestHandlerTest.js';
 import { TestRequest } from '../TestRequest.js';
-const url = new URL('http://localhost:8888/api/cors');
+
+const url = new URL('http://localhost:8888/api/cors.js');
 const referrer = 'http://localhost:9999';
 const headers = { Origin: referrer };
 
@@ -17,7 +18,11 @@ const { error } = await RequestHandlerTest.runTests(
 	new RequestHandlerTest(
 		new TestRequest(url, {
 			method: 'OPTIONS',
-			headers: { ...headers, 'Access-Control-Request-Method': 'POST', 'Access-Control-Request-Headers': 'Authorization' },
+			headers: {
+				...headers,
+				'Access-Control-Request-Method': 'POST',
+				'Access-Control-Request-Headers': 'Authorization',
+			},
 			referrer,
 		}),
 		[RequestHandlerTest.shouldBeCorsResponse, RequestHandlerTest.shouldPassPreflight]

--- a/tests/echo.js
+++ b/tests/echo.js
@@ -31,6 +31,7 @@ const referrer = origin;
 
 const headers = {
 	'Origin': origin,
+	'X-Foo': 'bar',
 };
 
 const signal = AbortSignal.timeout(500);
@@ -43,6 +44,7 @@ const { error } = await RequestHandlerTest.runTests(
 			RequestHandlerTest.shouldBeOk,
 			RequestHandlerTest.shouldHaveBody,
 			RequestHandlerTest.shouldBeJSONObject,
+			RequestHandlerTest.shouldRequireHeaders('X-Foo'),
 			RequestHandlerTest.shouldSetCookies('foo'),
 			RequestHandlerTest.shouldNotSetCookies('bar'),
 		]
@@ -63,8 +65,12 @@ const { error } = await RequestHandlerTest.runTests(
 		RequestHandlerTest.shouldBeOk
 	),
 	new RequestHandlerTest(
-		new TestRequest(url, { referrer, signal, searchParams: { test: 'json-keys' }}),
+		new TestRequest(url, { referrer, headers, signal, searchParams: { test: 'json-keys' }}),
 		[RequestHandlerTest.shouldHaveJSONKeys('url', 'headers')]
+	),
+	new RequestHandlerTest(
+		new TestRequest(url, { referrer, signal, searchParams: { test: 'missing-x-foo' }}),
+		[RequestHandlerTest.shouldClientError]
 	),
 	new RequestHandlerTest(
 		new TestRequest(url, {


### PR DESCRIPTION
- More request validation (headers, search params)
- More tests
- Constants for various HTTP Headers, etc (avoids typos)
- Add support for `URLPattern` in `allowOrigins`
- Support multiple types of return values and convert to `Response` (eg `Blob`, `URL`, numbers) as best as reasonable