### PR TITLE
fix: decodeRequestToken not bundled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.1.18] - 2024-09-22
+
+### Fixed
+- decodeRequestToken not bundled
 
 ## [v1.1.17] - 2024-09-19
 

--- a/handler.js
+++ b/handler.js
@@ -7,7 +7,7 @@ import { METHOD_NOT_ALLOWED, NO_CONTENT } from '@shgysk8zer0/consts/status.js';
 import { contextFallback } from './context.js';
 import { NetlifyRequest } from './NetlifyRequest.js';
 import { ACAO, ACAC, ACAM, ACAH, ACRH, ACEH, AUTH, ORIGIN, ALLOW, CONTENT_LENGTH } from './consts.js';
-import { decodeRequestToken } from '@shgysk8zer0/jwk-utils/jwt.js';
+import { decodeRequestToken } from '@shgysk8zer0/jwk-utils';
 
 const NO_BODY_METHODS = ['HEAD', 'GET', 'OPTIONS', 'DELETE'];
 const REDIRECT_CODES = [301, 302, 303, 307, 308];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/lambda-http",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "A collection of node >= 20 utilities for Netlify Functions and AWS Lambda",
   "keywords": [
     "request",


### PR DESCRIPTION
Fix for: https://answers.netlify.com/t/126029/

# Description and issue

`handler.js` explicitly specifies decoreRequestToken to be imported from a specific JS file. However, the package.json is correctly setup for bundlers to be able to analyze and import the required package correctly. Due to the way it's currently being imported, it ends up being dropped from Netlify's Function Bundle. This PR aims to fix that.

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  change import path
