### PR TITLE
Fix Cookie params and add JSDoc documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.2.2] - 2026-07-14
+
+### Fixed
+- Fix various params in `Cookie`
+
 ## [v1.2.1] - 2026-06-14
 
 ### Added

--- a/cookies.js
+++ b/cookies.js
@@ -1,21 +1,42 @@
+/**
+ * @typedef {"strict"|"lax"|"none"} SameSiteOption
+ */
+
+/**
+ * @typedef {object} CookieConfig
+ * @property {string} name The name of the cookie.
+ * @property {string} [value=""] The value of the cookie.
+ * @property {string} [path] The path for the cookie.
+ * @property {string} [domain] The domain for the cookie.
+ * @property {string|number|Date} [expires] The expiry details.
+ * @property {SameSiteOption} [sameSite] The SameSite attribute.
+ * @property {boolean} [httpOnly=false] Flags the cookie as HTTP-only.
+ * @property {boolean} [secure=false] Flags the cookie as secure.
+ * @property {boolean} [partitioned=false] Flags the cookie as partitioned.
+ */
+
 export class Cookie {
 	#name;
-	#value;
-	#path = '/';
+	#value = '';
+	#path;
 	#domain;
 	#expires;
-	#sameSite = 'Lax';
+	#sameSite;
 	#httpOnly = false;
 	#secure = false;
 	#partitioned = false;
 
+	/**
+	 *
+	 * @param {CookieConfig} config
+	 */
 	constructor({
 		name,
 		value = '',
-		path = '/',
+		path,
 		domain,
 		expires,
-		sameSite = 'lax',
+		sameSite,
 		httpOnly = false,
 		secure = false,
 		partitioned = false,
@@ -52,10 +73,16 @@ export class Cookie {
 		}
 	}
 
+	/**
+	 * @returns {string}
+	 */
 	get name() {
 		return this.#name;
 	}
 
+	/**
+	 * @param {string} name
+	 */
 	set name(val) {
 		if (typeof val === 'string') {
 			this.#name = val;
@@ -64,10 +91,16 @@ export class Cookie {
 		}
 	}
 
+	/**
+	 * @returns {string}
+	 */
 	get value() {
 		return this.#value;
 	}
 
+	/**
+	 * @param {string} val
+	 */
 	set value(val) {
 		if (typeof val === 'string') {
 			this.#value = val;
@@ -104,20 +137,29 @@ export class Cookie {
 		}
 	}
 
+	/**
+	 * @returns {string|undefined}
+	 */
 	get domain() {
 		return this.#domain;
 	}
 
+	/**
+	 * @param {string|URL} val
+	 */
 	set domain(val) {
 		if (val instanceof URL) {
 			this.#domain = val.hostname;
-		} else if (typeof val !== 'string' || val.length === '') {
+		} else if (typeof val !== 'string' || val.length === 0) {
 			throw new TypeError('Cookie domain must be a non-empty string.');
 		} else {
 			this.#domain = val;
 		}
 	}
 
+	/**
+	 * @returns {number|undefined}
+	 */
 	get expires() {
 		if (this.#expires instanceof Date) {
 			return this.#expires.getTime();
@@ -126,14 +168,17 @@ export class Cookie {
 		}
 	}
 
+	/**
+	 * @param {string|number|Date} val
+	 */
 	set expires(val) {
 		switch (typeof val) {
 			case 'string':
-				this.expires = new Date(val).getTime();
+				this.#expires = new Date(val);
 				break;
 
 			case 'number':
-				this.#expires = Number.isNaN(val) ? undefined : val;
+				this.#expires = Number.isNaN(val) ? undefined : new Date(val);
 				break;
 
 			case 'object':
@@ -142,7 +187,7 @@ export class Cookie {
 				} else if (! (val instanceof Date)) {
 					throw new TypeError('Invalid expires.');
 				} else {
-					this.#expires = val.getTime();
+					this.#expires = val;
 				}
 				break;
 
@@ -155,10 +200,16 @@ export class Cookie {
 		}
 	}
 
+	/**
+	 * @returns {boolean}
+	 */
 	get httpOnly() {
 		return this.#httpOnly;
 	}
 
+	/**
+	 * @param {boolean} val
+	 */
 	set httpOnly(val) {
 		if (typeof val !== 'boolean') {
 			throw new TypeError('Cookie httpOnly must be a boolean.');
@@ -167,10 +218,16 @@ export class Cookie {
 		}
 	}
 
+	/**
+	 * @returns {boolean}
+	 */
 	get partitioned() {
 		return this.#partitioned;
 	}
 
+	/**
+	 * @param {boolean} val
+	 */
 	set partitioned(val) {
 		if (typeof val !== 'boolean') {
 			throw new TypeError('Cookie partitioned must be a boolean.');
@@ -179,10 +236,16 @@ export class Cookie {
 		}
 	}
 
+	/**
+	 * @returns {string|undefined}
+	 */
 	get path() {
 		return this.#path;
 	}
 
+	/**
+	 * @param {string} val
+	 */
 	set path(val) {
 		if (val instanceof URL) {
 			this.#path = val.pathname;
@@ -193,10 +256,16 @@ export class Cookie {
 		}
 	}
 
+	/**
+	 * @returns {SameSiteOption}
+	 */
 	get sameSite() {
 		return this.#sameSite;
 	}
 
+	/**
+	 * @param {SameSiteOption} val
+	 */
 	set sameSite(val) {
 		if (typeof val !== 'string') {
 			throw new TypeError('Cookie SameSite must be a string.');
@@ -207,10 +276,16 @@ export class Cookie {
 		}
 	}
 
+	/**
+	 * @returns {boolean}
+	 */
 	get secure() {
 		return this.#secure;
 	}
 
+	/**
+	 * @param {boolean} val
+	 */
 	set secure(val) {
 		if (typeof val !== 'boolean') {
 			throw new TypeError('Cookie secure must be a boolean.');
@@ -220,22 +295,22 @@ export class Cookie {
 	}
 
 	toString() {
-		const parts = [`${this.#name}=${this.#value}`];
+		const parts = [`${this.#name}=${encodeURIComponent(this.#value)}`];
 
-		if (typeof this.#expires === 'number') {
-			parts.push(`Expires=${new Date(this.#expires).toUTCString()}`);
+		if (this.#expires instanceof Date) {
+			parts.push(`Expires=${this.#expires.toUTCString()}`);
 		}
 
 		if (typeof this.#domain === 'string') {
 			parts.push(`Domain=${this.#domain}`);
 		}
 
-		if (typeof this.#path === 'string' && this.#path !== '/') {
+		if (typeof this.#path === 'string') {
 			parts.push(`Path=${this.#path}`);
 		}
 
 		if (typeof this.#sameSite === 'string') {
-			parts.push(`SameSite=${this.sameSite[0].toUpperCase()}${this.#sameSite.substring(1).toLowerCase()}`);
+			parts.push(`SameSite=${this.#sameSite[0].toUpperCase()}${this.#sameSite.substring(1).toLowerCase()}`);
 		}
 
 		if (this.#httpOnly) {
@@ -257,14 +332,22 @@ export class Cookie {
 		return this.toString();
 	}
 
+	/**
+	 *
+	 * @param {Headers} headers
+	 */
 	addToHeaders(headers) {
 		if (! (headers instanceof Headers)) {
 			throw new TypeError('Expected a Headers object.');
 		} else {
-			headers.append('Set-Cookie', this);
+			headers.append('Set-Cookie', this.toString());
 		}
 	}
 
+	/**
+	 *
+	 * @param {Response} resp
+	 */
 	addToResponse(resp) {
 		if (resp instanceof Response) {
 			this.addToHeaders(resp.headers);
@@ -274,45 +357,97 @@ export class Cookie {
 	}
 }
 
-export class CookieStore {
+export class CookieStore extends EventTarget {
+	/**
+	 * @type {Map<string,Cookie>}
+	 */
 	#map = new Map();
 
+	/**
+	 *
+	 * @returns {MapIterator<Cookie>}
+	 */
 	[Symbol.iterator]() {
 		return this.values();
 	}
 
+	/**
+	 *
+	 * @returns {MapIterator<string>}
+	 */
 	keys() {
 		return this.#map.keys();
 	}
 
+	/**
+	 *
+	 * @returns {MapIterator<Cookie>}
+	 */
 	values() {
 		return this.#map.values();
 	}
 
+	/**
+	 *
+	 * @returns {MapIterator<[string, Cookie]>}
+	 */
 	entries() {
 		return this.#map.entries();
 	}
 
+	/**
+	 *
+	 * @param {string} name
+	 * @returns {boolean}
+	 */
 	has(name) {
-		return this.#map.has(name);
+		return typeof name === 'string' ? this.#map.has(name) : this.#map.has(name?.name);
 	}
 
+	/**
+	 *
+	 * @param {string} name
+	 * @returns {Cookie|null}
+	 */
 	get(name) {
-		return this.#map.get(name);
+		if (typeof name === 'string') {
+			return this.#map.get(name) ?? null;
+		} else if (typeof name?.name === 'string') {
+			return this.#map.get(name.name) ?? null;
+		} else {
+			return null;
+		}
 	}
 
+	/**
+	 *
+	 * @param {string} name
+	 * @returns {Cookie[]}
+	 * @todo Support multiple values/cookies
+	 */
 	getAll(name) {
-		return [this.get(name)];
+		return this.has(name) ? [this.get(name)] : [];
 	}
 
+	/**
+	 *
+	 * @param {string} name
+	 */
 	delete(name) {
 		if (this.has(name)) {
 			this.get(name).expires = 0;
+		} else if (typeof name === 'object' && typeof name?.name === 'string') {
+			this.set({ ...name, value: '', expires: 0 });
 		} else {
 			this.set({ name, value: '', expires: 0 });
 		}
 	}
 
+	/**
+	 *
+	 * @param {string} arg
+	 * @param {string|Cookie|CookieConfig} value
+	 */
 	set(arg, value) {
 		if (typeof arg === 'string') {
 			const cookie = new Cookie({ name: arg, value });
@@ -320,7 +455,7 @@ export class CookieStore {
 			this.#map.set(cookie.name, cookie);
 		} else if (arg instanceof Cookie) {
 			this.#map.set(arg.name, arg);
-		} else if (typeof arg === 'object' && arg !== null) {
+		} else if (typeof arg === 'object' && arg !== null && typeof arg.name === 'string') {
 			const cookie = new Cookie(arg);
 
 			this.#map.set(cookie.name, cookie);
@@ -329,21 +464,66 @@ export class CookieStore {
 		}
 	}
 
+	/**
+	 *
+	 * @param {Headers} headers
+	 */
 	addToHeaders(headers) {
 		if (! (headers instanceof Headers)) {
 			throw new TypeError('Expected a Headers object.');
 		} else {
 			for (const cookie of this) {
-				headers.append('Set-Cookie', cookie);
+				headers.append('Set-Cookie', cookie.toString());
 			}
 		}
 	}
 
+	/**
+	 *
+	 * @param {Response} resp
+	 */
 	addToResponse(resp) {
 		if (! (resp instanceof Response)) {
 			throw new TypeError('Expected a Response object.');
 		} else {
 			this.addToHeaders(resp.headers);
+		}
+	}
+
+	/**
+	 *
+	 * @param {Headers} headers
+	 * @returns {CookieStore}
+	 */
+	static fromHeaders(headers) {
+		if (headers instanceof Headers) {
+			const store = new CookieStore();
+
+			if (headers.has('Cookie')) {
+				const cookies = headers.get('Cookie').split(';');
+
+				for (const cookie of cookies) {
+					const [name, ...values] = cookie.trim().split('=');
+					store.set(name, values.map(decodeURIComponent).join('='));
+				}
+			}
+
+			return store;
+		} else {
+			throw new TypeError('Not a Headers object.');
+		}
+	}
+
+	/**
+	 *
+	 * @param {Request} req
+	 * @return {CookieStore}
+	 */
+	static fromRequest(req) {
+		if (req instanceof Request) {
+			return CookieStore.fromHeaders(req.headers);
+		} else {
+			throw new TypeError('Not a Request object.');
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/lambda-http",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/lambda-http",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/lambda-http",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A collection of node >= 20 utilities for Netlify Functions and AWS Lambda",
   "keywords": [
     "request",


### PR DESCRIPTION
Fix various bugs in Cookie and CookieStore classes:
- Remove default values for optional params (path, sameSite)
- Fix expires setter to store Date objects consistently
- Fix toString() to properly encode values and check expires type
- Add comprehensive JSDoc type definitions and comments
- Fix CookieStore.has()/get() to accept Cookie objects
- Add static fromHeaders() and fromRequest() factory methods
- Fix addToHeaders() methods to call toString() on cookies
- CookieStore now extends EventTarget

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
